### PR TITLE
docs(readme): add standard status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ClassifAI
 
+[![Release](https://img.shields.io/github/v/release/fjacquet/classifai?sort=semver)](https://github.com/fjacquet/classifai/releases/latest)
+
 Automatically organize files using a hybrid of YAML rules and a local LLM
 via [Ollama](https://ollama.ai). Privacy-first, offline-capable,
 extensible by editing YAML.


### PR DESCRIPTION
Adds the standard README badge set (CI + latest release + license where applicable) to match the rest of the fleet. Docs-only.